### PR TITLE
fix: update `assembly` subtypes to point to assembly FASTA directly

### DIFF
--- a/src/metasmith/std/transforms/flye.py
+++ b/src/metasmith/std/transforms/flye.py
@@ -23,7 +23,7 @@ def protocol(context: ExecutionContext):
             flye \
                 --pacbio-raw \
                 {reads_path.container} \
-                --out-dir {out_path.container} \
+                --out-dir {out_path.container.parent} \
                 {cpus_string}
         """
     )
@@ -33,6 +33,6 @@ TransformInstance(
     protocol = protocol,
     model = model,
     output_signature = {
-        out: "long_reads_assembly/",
+        out: "long_reads_assembly/assembly.fasta",
     },
 )

--- a/src/metasmith/std/transforms/megahit.py
+++ b/src/metasmith/std/transforms/megahit.py
@@ -15,7 +15,7 @@ def protocol(context: ExecutionContext):
         cmd = f"""
                 megahit \
                     -r {reads_path.container} \
-                    -o {out_path.container}
+                    -o {out_path.container.parent}
         """
     )
     return ExecutionResult(success=out_path.local.exists())
@@ -24,6 +24,6 @@ TransformInstance(
     protocol = protocol,
     model = model,
     output_signature = {
-        out: "short_reads_assembly/",
+        out: "short_reads_assembly/final.contigs.fa",
     },
 )

--- a/src/metasmith/std/transforms/minimap2.py
+++ b/src/metasmith/std/transforms/minimap2.py
@@ -11,7 +11,7 @@ out        = model.AddProduct(lib.GetType("std::sequence_alignment_map"))
 def protocol(context: ExecutionContext):
     out_path = context.Get(out)
     reads_path = context.Get(reads)
-    assembly_path_container = context.Get(assembly).container / "00-assembly/draft_assembly.fasta"
+    assembly_path_container = context.Get(assembly).container
     context.ExecWithContainer(
         image = image,
         cmd = f"""

--- a/src/metasmith/std/transforms/pilon.py
+++ b/src/metasmith/std/transforms/pilon.py
@@ -10,7 +10,7 @@ out     = model.AddProduct(lib.GetType("std::hybrid_assembly"))
 
 def protocol(context: ExecutionContext):
     out_path = context.Get(out)
-    assembly_path = context.Get(assembly).container / "00-assembly/draft_assembly.fasta"
+    assembly_path = context.Get(assembly).container
     bam_dir = context.Get(bam).container
 
     cpus = context.params.get("cpus")
@@ -26,13 +26,11 @@ def protocol(context: ExecutionContext):
     context.ExecWithContainer(
         image = image,
         cmd = f"""
-                mkdir -p {out_path.container}
-                cd {out_path.container}
+                cd {out_path.container.parent}
                 java {memory_string} -jar \
                     /pilon/pilon.jar \
                         --genome {assembly_path} \
                         --frags {bam_dir / "alignments.sorted.bam"} \
-                        --output pilon_out \
                         {cpus_string} \
                         --fix all
         """
@@ -43,6 +41,6 @@ TransformInstance(
     protocol = protocol,
     model = model,
     output_signature = {
-        out: "pilon_out/",
+        out: "pilon_out/pilon.fasta",
     },
 )

--- a/src/metasmith/std/transforms/polypolish.py
+++ b/src/metasmith/std/transforms/polypolish.py
@@ -10,7 +10,7 @@ out     = model.AddProduct(lib.GetType("std::assembly"))
 
 def protocol(context: ExecutionContext):
     out_path = context.Get(out)
-    assembly_path = context.Get(assembly).container / "00-assembly/draft_assembly.fasta"
+    assembly_path = context.Get(assembly).container
     sam_path = context.Get(sam)
 
     context.ExecWithContainer(


### PR DESCRIPTION
Just a small fix for `short_reads_assembly`, `long_reads_assembly`, ...