### PR TITLE
Add DataInstanceLibrary.RenameByParent() and Library optimizations

### DIFF
--- a/src/metasmith/models/libraries.py
+++ b/src/metasmith/models/libraries.py
@@ -507,6 +507,82 @@ class DataInstanceLibrary:
             del self.parents[path]
         if _save: self.Save()
 
+    def RenameByParent(self, parent_type: str):
+        """
+        Rename all items in the library based on the path stem of their parent of the given type.
+        Uses a transactional approach: plans all renames, executes filesystem moves, then commits manifest atomically.
+        """
+        # Phase A — Plan (read-only)
+        rename_plan: list[tuple[Path, Path]] = []  # (old_path, proposed_new_path)
+
+        for item_path, item_type in self.manifest.items():
+            if item_type == parent_type:
+                continue
+            if item_path not in self.parents:
+                continue
+            matching_parents = [p for p in self.parents[item_path] if p.name == parent_type]
+            if not matching_parents:
+                continue
+            matching_parents.sort(key=lambda p: str(p.path))
+            parent = matching_parents[0]
+            new_path = item_path.parent / (parent.path.stem + item_path.suffix)
+            rename_plan.append((item_path, new_path))
+
+        # Detect collisions: group by (directory, new_filename)
+        # Also account for non-renamed items that occupy target paths
+        occupied_paths = {p for p in self.manifest if p not in {old for old, _ in rename_plan}}
+        final_plan: list[tuple[Path, Path]] = []
+        seen: dict[Path, list[int]] = {}  # new_path -> list of indices in rename_plan
+        for i, (old, new) in enumerate(rename_plan):
+            seen.setdefault(new, []).append(i)
+
+        for new_path, indices in seen.items():
+            needs_hash = len(indices) > 1 or new_path in occupied_paths
+            for idx in indices:
+                old, proposed = rename_plan[idx]
+                if needs_hash:
+                    _, hash_str = KeyGenerator.FromStr(str(old), l=8)
+                    final_new = old.parent / (proposed.stem + "_" + hash_str + proposed.suffix)
+                else:
+                    final_new = proposed
+                if old != final_new:
+                    final_plan.append((old, final_new))
+
+        if not final_plan:
+            return
+
+        # Execute filesystem moves
+        completed: list[tuple[Path, Path]] = []
+        try:
+            for old, new in final_plan:
+                abs_old = old if old.is_absolute() else self.location / old
+                abs_new = new if new.is_absolute() else self.location / new
+                abs_new.parent.mkdir(parents=True, exist_ok=True)
+                abs_old.rename(abs_new)
+                completed.append((old, new))
+        except Exception:
+            # Rollback: move completed renames back to originals
+            for orig, renamed in completed:
+                abs_renamed = renamed if renamed.is_absolute() else self.location / renamed
+                abs_orig = orig if orig.is_absolute() else self.location / orig
+                if abs_renamed.exists():
+                    abs_renamed.rename(abs_orig)
+            raise
+
+        # Commit manifest atomically
+        for old, new in final_plan:
+            self.manifest[new] = self.manifest[old]
+            del self.manifest[old]
+            if old in self.parents:
+                self.parents[new] = self.parents[old]
+                del self.parents[old]
+            # Update parent references that point to old path
+            for key, parent_list in self.parents.items():
+                for pm in parent_list:
+                    if pm.path == old:
+                        pm.path = new
+        self.Save()
+
     def AddParentsTo(self, path: Path|str, parents: Iterable[DataInstance]):
         if all(False for _ in parents):
             return # there were no parents

--- a/src/metasmith/models/libraries.py
+++ b/src/metasmith/models/libraries.py
@@ -239,6 +239,7 @@ class DataInstanceLibrary:
         self._dtype2name = {}
         self.remote_src: Source|None = None
         self.parents: dict[Path, list[DataInstanceLibrary.ParentMetadata]] = {}
+        self._endpoint_cache: dict[Path, Endpoint] = {}
         if isinstance(location, DataInstanceLibrary):
             other = location
             self.location = other.location
@@ -327,6 +328,8 @@ class DataInstanceLibrary:
             # Avoid infinite recursion
             e_name = self.manifest[path]
             return self.GetType(e_name)
+        if path in self._endpoint_cache:
+            return self._endpoint_cache[path]
         _seen.add(path)
 
         e_name = self.manifest[path]
@@ -337,6 +340,7 @@ class DataInstanceLibrary:
                 parent_ep = self._build_endpoint_with_lineage(parent_meta.path, _seen)
                 parent_endpoints.add(parent_ep)
             e = Endpoint(e.properties, parent_endpoints)
+        self._endpoint_cache[path] = e
         return e
 
     def GetType(self, name: str):
@@ -387,13 +391,22 @@ class DataInstanceLibrary:
                         to_check.append(p.path)
             return ancestors
 
+        # Build children_of reverse index once — O(N×P)
+        children_of: dict[Path, set[Path]] = {}
+        for item_path, parent_list in self.parents.items():
+            for pm in parent_list:
+                children_of.setdefault(pm.path, set()).add(item_path)
+
         def _get_all_descendants(ancestor_paths: set[Path]) -> set[Path]:
-            """Get all items that have any of the given paths as an ancestor."""
+            """BFS down children_of index to find all descendants."""
             descendants = set()
-            for item_path in self.manifest.keys():
-                item_ancestors = _get_all_ancestors(item_path)
-                if item_ancestors & ancestor_paths:  # If they share any ancestor
-                    descendants.add(item_path)
+            queue = list(ancestor_paths)
+            while queue:
+                current = queue.pop()
+                for child in children_of.get(current, set()):
+                    if child not in descendants:
+                        descendants.add(child)
+                        queue.append(child)
             return descendants
 
         for path, name in self.manifest.items():
@@ -453,6 +466,7 @@ class DataInstanceLibrary:
         type_model = self.GetType(dtype) # check if datatype exists
         self.manifest[path] = dtype
         self.AddParentsTo(path, [self.Get(p) for p in parents])
+        self._invalidate_endpoint_cache()
         return path
 
     def AddValue(self, name: str, value: str|dict, dtype: str, parents: Iterable[Path]|None=None):
@@ -464,6 +478,9 @@ class DataInstanceLibrary:
             f.write(value)
         return path
 
+    def _invalidate_endpoint_cache(self):
+        self._endpoint_cache.clear()
+
     def Remove(self, path: Path):
         assert path in self.manifest, f"not found [{path}]"
         try:
@@ -472,10 +489,11 @@ class DataInstanceLibrary:
             del self.manifest[K]
         except RuntimeError:
             assert False, f"can not make changes while iterating library"
-        
+
         del self.manifest[path]
         if path in self.parents:
             del self.parents[path]
+        self._invalidate_endpoint_cache()
 
     def Rename(self, path: Path, new: Path, _save=True):
         """
@@ -505,6 +523,7 @@ class DataInstanceLibrary:
         if path in self.parents:
             self.parents[new] = self.parents[path]
             del self.parents[path]
+        self._invalidate_endpoint_cache()
         if _save: self.Save()
 
     def RenameByParent(self, parent_type: str):
@@ -530,7 +549,8 @@ class DataInstanceLibrary:
 
         # Detect collisions: group by (directory, new_filename)
         # Also account for non-renamed items that occupy target paths
-        occupied_paths = {p for p in self.manifest if p not in {old for old, _ in rename_plan}}
+        renamed_old_paths = {old for old, _ in rename_plan}
+        occupied_paths = {p for p in self.manifest if p not in renamed_old_paths}
         final_plan: list[tuple[Path, Path]] = []
         seen: dict[Path, list[int]] = {}  # new_path -> list of indices in rename_plan
         for i, (old, new) in enumerate(rename_plan):
@@ -569,18 +589,21 @@ class DataInstanceLibrary:
                     abs_renamed.rename(abs_orig)
             raise
 
-        # Commit manifest atomically
+        # Commit manifest atomically — two-phase for O(N×P) instead of O(R×N×P)
+        old_to_new = {old: new for old, new in final_plan}
+        # Phase 1: Move manifest and parents keys
         for old, new in final_plan:
             self.manifest[new] = self.manifest[old]
             del self.manifest[old]
             if old in self.parents:
                 self.parents[new] = self.parents[old]
                 del self.parents[old]
-            # Update parent references that point to old path
-            for key, parent_list in self.parents.items():
-                for pm in parent_list:
-                    if pm.path == old:
-                        pm.path = new
+        # Phase 2: Single pass to update all parent references
+        for parent_list in self.parents.values():
+            for pm in parent_list:
+                if pm.path in old_to_new:
+                    pm.path = old_to_new[pm.path]
+        self._invalidate_endpoint_cache()
         self.Save()
 
     def AddParentsTo(self, path: Path|str, parents: Iterable[DataInstance]):
@@ -593,11 +616,15 @@ class DataInstanceLibrary:
             return f"{d.parent_lib.GetKey()}/{d.path}"
         current += [self.ParentMetadata(p.dtype, p.dtype_name, p.parent_lib.GetKey(), p.path) for p in parents if _get_k(p) not in seen]
         self.parents[p] = current
+        self._invalidate_endpoint_cache()
 
-    def _calculate_key(self):
-        me_d = self.Pack()
-        for k in ["remote_src"]:
-            if k in me_d: del me_d[k]
+    def _calculate_key(self, _raw_override=None):
+        if _raw_override is not None:
+            me_d = {k: v for k, v in _raw_override.items() if k != "remote_src"}
+        else:
+            me_d = self.Pack()
+            for k in ["remote_src"]:
+                if k in me_d: del me_d[k]
         me = yaml.dump(me_d)
         self._hash, self._key = KeyGenerator.FromStr(me, l=12)
         return self._key
@@ -691,19 +718,26 @@ class DataInstanceLibrary:
             if len(parents) > 0:
                 lib.parents[Path(k)] = list(parents.values())
 
-        # Second pass: Aggregate grandparents (now all immediate parents are populated)
+        # Second pass: Memoized transitive closure for full ancestor aggregation
+        ancestor_cache: dict[Path, dict[Path, DataInstanceLibrary.ParentMetadata]] = {}
+
+        def _get_all_ancestors(k_path: Path) -> dict[Path, DataInstanceLibrary.ParentMetadata]:
+            if k_path in ancestor_cache:
+                return ancestor_cache[k_path]
+            ancestors: dict[Path, DataInstanceLibrary.ParentMetadata] = {}
+            for p in lib.parents.get(k_path, []):
+                ancestors[p.path] = p
+                for gp_path, gp in _get_all_ancestors(p.path).items():
+                    if gp_path not in ancestors:
+                        ancestors[gp_path] = gp
+            ancestor_cache[k_path] = ancestors
+            return ancestors
+
         for k in raw["manifest"].keys():
             k_path = Path(k)
             if k_path not in lib.parents:
                 continue
-            ancestors: dict[Path, DataInstanceLibrary.ParentMetadata] = {}
-            for p in lib.parents[k_path]:
-                ancestors[p.path] = p
-                # Recursively collect all ancestors
-                for gp in lib.parents.get(p.path, []):
-                    if gp.path not in ancestors:
-                        ancestors[gp.path] = gp
-            lib.parents[k_path] = list(ancestors.values())
+            lib.parents[k_path] = list(_get_all_ancestors(k_path).values())
 
         return lib
 
@@ -744,7 +778,7 @@ class DataInstanceLibrary:
         d = yaml_safe_load(index_path)
         self = cls.Unpack(location=path, raw=d, dtypes=dtypes, check_integrity=check_integrity)
         self.types = dtypes
-        self._calculate_key()
+        self._calculate_key(_raw_override=d)
         return self
 
     def PrepTransfer(self, dest: Source, mover: Logistics|None=None):

--- a/tests/models/test_libraries.py
+++ b/tests/models/test_libraries.py
@@ -618,3 +618,240 @@ class TestDataInstanceLibraryTrace:
             bam_path = str(sample_map[i]["bam"])
             meta_path = str(sample_map[i]["meta"])
             assert bam_to_meta[bam_path] == meta_path
+
+
+class TestDataInstanceLibraryRenameByParent:
+    """Tests for DataInstanceLibrary.RenameByParent method."""
+
+    @pytest.fixture
+    def temp_dir(self):
+        d = tempfile.mkdtemp()
+        yield Path(d)
+        shutil.rmtree(d)
+
+    @pytest.fixture
+    def mock_types(self, temp_dir) -> Path:
+        types = DataTypeLibrary()
+        types["metadata"] = Endpoint(properties={"metadata"})
+        types["reads"] = Endpoint(properties={"reads"})
+        types["assembly"] = Endpoint(properties={"assembly"})
+        types["qc_stats"] = Endpoint(properties={"qc_stats"})
+        types["bam"] = Endpoint(properties={"bam"})
+        types_path = temp_dir / "mock_types.yml"
+        types.Save(types_path)
+        return types_path
+
+    def _make_lib(self, temp_dir, mock_types, name="lib"):
+        lib_path = temp_dir / name
+        lib = DataInstanceLibrary(lib_path)
+        lib.AddTypeLibrary(mock_types, namespace="mock")
+        return lib, lib_path
+
+    def _make_file(self, lib_path, rel_path):
+        p = lib_path / rel_path
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("content")
+
+    # --- Basic rename ---
+
+    def test_basic_rename(self, temp_dir, mock_types):
+        """1 sample: metadata -> reads -> assembly. Rename by mock::metadata gives metadata's stem."""
+        lib, lib_path = self._make_lib(temp_dir, mock_types)
+        self._make_file(lib_path, "s1/sample_A.json")
+        self._make_file(lib_path, "s1/abc123.fq")
+        self._make_file(lib_path, "s1/def456.fa")
+        m = lib.AddItem(Path("s1/sample_A.json"), "mock::metadata")
+        r = lib.AddItem(Path("s1/abc123.fq"), "mock::reads", parents=[m])
+        a = lib.AddItem(Path("s1/def456.fa"), "mock::assembly", parents=[r])
+        lib.Save()
+        loaded = DataInstanceLibrary.Load(lib_path)
+
+        loaded.RenameByParent("mock::metadata")
+
+        assert Path("s1/sample_A.fq") in loaded.manifest
+        assert Path("s1/sample_A.fa") in loaded.manifest
+        assert Path("s1/sample_A.json") in loaded.manifest  # parent type item unchanged
+        assert loaded.manifest[Path("s1/sample_A.fq")] == "mock::reads"
+        assert loaded.manifest[Path("s1/sample_A.fa")] == "mock::assembly"
+
+    def test_preserves_extensions(self, temp_dir, mock_types):
+        """Files with different extensions all keep their suffixes."""
+        lib, lib_path = self._make_lib(temp_dir, mock_types)
+        self._make_file(lib_path, "my_sample.json")
+        self._make_file(lib_path, "hash1.fq")
+        self._make_file(lib_path, "hash2.fa")
+        self._make_file(lib_path, "hash3.bam")
+        m = lib.AddItem(Path("my_sample.json"), "mock::metadata")
+        r = lib.AddItem(Path("hash1.fq"), "mock::reads", parents=[m])
+        a = lib.AddItem(Path("hash2.fa"), "mock::assembly", parents=[m])
+        b = lib.AddItem(Path("hash3.bam"), "mock::bam", parents=[m])
+        lib.Save()
+        loaded = DataInstanceLibrary.Load(lib_path)
+
+        loaded.RenameByParent("mock::metadata")
+
+        assert Path("my_sample.fq") in loaded.manifest
+        assert Path("my_sample.fa") in loaded.manifest
+        assert Path("my_sample.bam") in loaded.manifest
+
+    def test_skips_parent_type_items(self, temp_dir, mock_types):
+        """Items of the parent type itself are not renamed."""
+        lib, lib_path = self._make_lib(temp_dir, mock_types)
+        self._make_file(lib_path, "sample.json")
+        self._make_file(lib_path, "hash.fq")
+        m = lib.AddItem(Path("sample.json"), "mock::metadata")
+        r = lib.AddItem(Path("hash.fq"), "mock::reads", parents=[m])
+        lib.Save()
+        loaded = DataInstanceLibrary.Load(lib_path)
+
+        loaded.RenameByParent("mock::metadata")
+
+        # metadata item path unchanged
+        assert Path("sample.json") in loaded.manifest
+        assert loaded.manifest[Path("sample.json")] == "mock::metadata"
+
+    def test_skips_items_without_matching_parent(self, temp_dir, mock_types):
+        """Orphan items (no parent of given type) are unchanged."""
+        lib, lib_path = self._make_lib(temp_dir, mock_types)
+        self._make_file(lib_path, "orphan.fa")
+        self._make_file(lib_path, "sample.json")
+        self._make_file(lib_path, "linked.fq")
+        lib.AddItem(Path("orphan.fa"), "mock::assembly")  # no parent
+        m = lib.AddItem(Path("sample.json"), "mock::metadata")
+        lib.AddItem(Path("linked.fq"), "mock::reads", parents=[m])
+        lib.Save()
+        loaded = DataInstanceLibrary.Load(lib_path)
+
+        loaded.RenameByParent("mock::metadata")
+
+        assert Path("orphan.fa") in loaded.manifest  # unchanged
+
+    def test_multiple_samples_no_collision(self, temp_dir, mock_types):
+        """3 samples with unique metadata stems in separate dirs → clean rename."""
+        lib, lib_path = self._make_lib(temp_dir, mock_types)
+        for i, name in enumerate(["alpha", "beta", "gamma"]):
+            self._make_file(lib_path, f"s{i}/{name}.json")
+            self._make_file(lib_path, f"s{i}/hash{i}.fq")
+            m = lib.AddItem(Path(f"s{i}/{name}.json"), "mock::metadata")
+            lib.AddItem(Path(f"s{i}/hash{i}.fq"), "mock::reads", parents=[m])
+        lib.Save()
+        loaded = DataInstanceLibrary.Load(lib_path)
+
+        loaded.RenameByParent("mock::metadata")
+
+        assert Path("s0/alpha.fq") in loaded.manifest
+        assert Path("s1/beta.fq") in loaded.manifest
+        assert Path("s2/gamma.fq") in loaded.manifest
+
+    def test_collision_adds_hash(self, temp_dir, mock_types):
+        """2 items with same parent stem in same directory → both get _<hash> suffix."""
+        lib, lib_path = self._make_lib(temp_dir, mock_types)
+        self._make_file(lib_path, "sample.json")
+        self._make_file(lib_path, "hash1.fa")
+        self._make_file(lib_path, "hash2.fq")
+        m = lib.AddItem(Path("sample.json"), "mock::metadata")
+        # Both children would want to be named "sample.*" but .fa and .fq have different suffixes
+        # so no collision. Let's create a real collision with same suffix.
+        a1 = lib.AddItem(Path("hash1.fa"), "mock::assembly", parents=[m])
+        a2 = lib.AddItem(Path("hash2.fq"), "mock::reads", parents=[m])
+
+        # Actually for a real collision we need same target filename. Use same extension items.
+        # Let me use a different setup: two assemblies with same parent in same dir.
+        # But manifest keys must be unique. Let's use qc_stats too.
+        lib2, lib_path2 = self._make_lib(temp_dir, mock_types, name="lib2")
+        self._make_file(lib_path2, "sample.json")
+        self._make_file(lib_path2, "hash1.json")  # reads with .json extension - will collide with sample.json
+        m = lib2.AddItem(Path("sample.json"), "mock::metadata")
+        r = lib2.AddItem(Path("hash1.json"), "mock::reads", parents=[m])
+        lib2.Save()
+        loaded = DataInstanceLibrary.Load(lib_path2)
+
+        loaded.RenameByParent("mock::metadata")
+
+        # hash1.json wants to become sample.json, but that's already occupied by metadata
+        # So it should get a hash suffix
+        renamed_reads = [p for p in loaded.manifest if loaded.manifest[p] == "mock::reads"]
+        assert len(renamed_reads) == 1
+        name = renamed_reads[0].name
+        assert name.startswith("sample_") and name.endswith(".json")
+        assert name != "sample.json"  # has hash appended
+
+    def test_no_collision_across_directories(self, temp_dir, mock_types):
+        """Same parent stems in different directories → no hash needed."""
+        lib, lib_path = self._make_lib(temp_dir, mock_types)
+        # Two samples with same metadata stem but in different dirs
+        for d in ["dir1", "dir2"]:
+            self._make_file(lib_path, f"{d}/sample.json")
+            self._make_file(lib_path, f"{d}/hash.fq")
+            m = lib.AddItem(Path(f"{d}/sample.json"), "mock::metadata")
+            lib.AddItem(Path(f"{d}/hash.fq"), "mock::reads", parents=[m])
+        lib.Save()
+        loaded = DataInstanceLibrary.Load(lib_path)
+
+        loaded.RenameByParent("mock::metadata")
+
+        # Both should be cleanly renamed without hash
+        assert Path("dir1/sample.fq") in loaded.manifest
+        assert Path("dir2/sample.fq") in loaded.manifest
+
+    def test_filesystem_reflects_rename(self, temp_dir, mock_types):
+        """Old files gone, new files present on disk."""
+        lib, lib_path = self._make_lib(temp_dir, mock_types)
+        self._make_file(lib_path, "sample_A.json")
+        self._make_file(lib_path, "abc123.fq")
+        m = lib.AddItem(Path("sample_A.json"), "mock::metadata")
+        lib.AddItem(Path("abc123.fq"), "mock::reads", parents=[m])
+        lib.Save()
+        loaded = DataInstanceLibrary.Load(lib_path)
+
+        loaded.RenameByParent("mock::metadata")
+
+        assert not (lib_path / "abc123.fq").exists()
+        assert (lib_path / "sample_A.fq").exists()
+        assert (lib_path / "sample_A.json").exists()  # parent unchanged
+
+    def test_save_load_roundtrip(self, temp_dir, mock_types):
+        """After rename, save/load preserves manifest and lineage."""
+        lib, lib_path = self._make_lib(temp_dir, mock_types)
+        self._make_file(lib_path, "s1/sample_A.json")
+        self._make_file(lib_path, "s1/hash1.fq")
+        self._make_file(lib_path, "s1/hash2.fa")
+        m = lib.AddItem(Path("s1/sample_A.json"), "mock::metadata")
+        r = lib.AddItem(Path("s1/hash1.fq"), "mock::reads", parents=[m])
+        a = lib.AddItem(Path("s1/hash2.fa"), "mock::assembly", parents=[r])
+        lib.Save()
+        loaded = DataInstanceLibrary.Load(lib_path)
+
+        loaded.RenameByParent("mock::metadata")
+
+        # Load again and verify
+        reloaded = DataInstanceLibrary.Load(lib_path)
+        assert Path("s1/sample_A.fq") in reloaded.manifest
+        assert Path("s1/sample_A.fa") in reloaded.manifest
+        assert reloaded.manifest[Path("s1/sample_A.fq")] == "mock::reads"
+        assert reloaded.manifest[Path("s1/sample_A.fa")] == "mock::assembly"
+
+        # Verify lineage is preserved
+        assert Path("s1/sample_A.fq") in reloaded.parents
+        parent_names = {p.name for p in reloaded.parents[Path("s1/sample_A.fq")]}
+        assert "mock::metadata" in parent_names
+
+    def test_manifest_unchanged_on_error(self, temp_dir, mock_types):
+        """If a filesystem rename fails, manifest is unchanged (transactional safety)."""
+        lib, lib_path = self._make_lib(temp_dir, mock_types)
+        self._make_file(lib_path, "sample.json")
+        self._make_file(lib_path, "hash1.fq")
+        m = lib.AddItem(Path("sample.json"), "mock::metadata")
+        lib.AddItem(Path("hash1.fq"), "mock::reads", parents=[m])
+        lib.Save()
+        loaded = DataInstanceLibrary.Load(lib_path)
+
+        # Remove the file to cause a rename error
+        (lib_path / "hash1.fq").unlink()
+
+        original_manifest = dict(loaded.manifest)
+        with pytest.raises(Exception):
+            loaded.RenameByParent("mock::metadata")
+
+        # Manifest should be unchanged
+        assert loaded.manifest == original_manifest

--- a/tests/models/test_libraries.py
+++ b/tests/models/test_libraries.py
@@ -855,3 +855,114 @@ class TestDataInstanceLibraryRenameByParent:
 
         # Manifest should be unchanged
         assert loaded.manifest == original_manifest
+
+
+class TestDataInstanceLibraryPerformance:
+    """Performance tests for DataInstanceLibrary with 10k samples."""
+
+    @pytest.fixture
+    def temp_dir(self):
+        d = tempfile.mkdtemp()
+        yield Path(d)
+        shutil.rmtree(d)
+
+    @pytest.fixture
+    def mock_types(self, temp_dir) -> Path:
+        types = DataTypeLibrary()
+        types["metadata"] = Endpoint(properties={"metadata"})
+        types["reads"] = Endpoint(properties={"reads"})
+        types["assembly"] = Endpoint(properties={"assembly"})
+        types["bam"] = Endpoint(properties={"bam"})
+        types_path = temp_dir / "mock_types.yml"
+        types.Save(types_path)
+        return types_path
+
+    def _build_10k_lib(self, temp_dir, mock_types, n=10000):
+        """Create a library with n samples, each with lineage: metadata -> reads -> assembly -> bam."""
+        lib_path = temp_dir / "lib"
+        lib = DataInstanceLibrary(lib_path)
+        lib.AddTypeLibrary(mock_types, namespace="mock")
+
+        for i in range(n):
+            d = f"s{i:05d}"
+            for f in ["meta.json", "reads.fq", "asm.fa", "out.bam"]:
+                p = lib_path / d / f
+                p.parent.mkdir(parents=True, exist_ok=True)
+                p.write_text("")
+            m = lib.AddItem(Path(f"{d}/meta.json"), "mock::metadata")
+            r = lib.AddItem(Path(f"{d}/reads.fq"), "mock::reads", parents=[m])
+            a = lib.AddItem(Path(f"{d}/asm.fa"), "mock::assembly", parents=[r])
+            lib.AddItem(Path(f"{d}/out.bam"), "mock::bam", parents=[a])
+
+        lib.Save()
+        return lib_path
+
+    def test_save_load_10k(self, temp_dir, mock_types):
+        """Load 10k-sample library under 30s."""
+        import time
+        lib_path = self._build_10k_lib(temp_dir, mock_types)
+
+        start = time.time()
+        loaded = DataInstanceLibrary.Load(lib_path)
+        elapsed = time.time() - start
+
+        assert len(loaded.manifest) == 40000
+        assert elapsed < 30, f"Load took {elapsed:.1f}s (limit 30s)"
+
+    def test_as_samples_10k(self, temp_dir, mock_types):
+        """AsSamples iteration over 10k samples under 30s."""
+        import time
+        lib_path = self._build_10k_lib(temp_dir, mock_types)
+        loaded = DataInstanceLibrary.Load(lib_path)
+
+        start = time.time()
+        count = sum(1 for _ in loaded.AsSamples("mock::metadata"))
+        elapsed = time.time() - start
+
+        assert count == 10000
+        assert elapsed < 30, f"AsSamples took {elapsed:.1f}s (limit 30s)"
+
+    def test_trace_10k(self, temp_dir, mock_types):
+        """Trace across 10k samples under 30s."""
+        import time
+        lib_path = self._build_10k_lib(temp_dir, mock_types)
+        loaded = DataInstanceLibrary.Load(lib_path)
+
+        start = time.time()
+        results = list(loaded.Trace("mock::bam", "mock::metadata"))
+        elapsed = time.time() - start
+
+        assert len(results) == 10000
+        assert elapsed < 30, f"Trace took {elapsed:.1f}s (limit 30s)"
+
+    def test_rename_by_parent_10k(self, temp_dir, mock_types):
+        """RenameByParent on 10k samples under 60s."""
+        import time
+        lib_path = self._build_10k_lib(temp_dir, mock_types)
+        loaded = DataInstanceLibrary.Load(lib_path)
+
+        start = time.time()
+        loaded.RenameByParent("mock::metadata")
+        elapsed = time.time() - start
+
+        assert elapsed < 60, f"RenameByParent took {elapsed:.1f}s (limit 60s)"
+        # Verify reads were renamed to use metadata stem
+        renamed_reads = [p for p, t in loaded.manifest.items() if t == "mock::reads"]
+        assert len(renamed_reads) == 10000
+        assert all(p.stem == "meta" for p in renamed_reads)
+
+    def test_save_load_roundtrip_10k(self, temp_dir, mock_types):
+        """Pack equivalence after round-trip on 10k samples under 60s."""
+        import time
+        lib_path = self._build_10k_lib(temp_dir, mock_types)
+
+        start = time.time()
+        loaded = DataInstanceLibrary.Load(lib_path)
+        packed1 = loaded.Pack()
+        loaded.Save()
+        reloaded = DataInstanceLibrary.Load(lib_path)
+        packed2 = reloaded.Pack()
+        elapsed = time.time() - start
+
+        assert packed1["manifest"] == packed2["manifest"]
+        assert elapsed < 60, f"Round-trip took {elapsed:.1f}s (limit 60s)"


### PR DESCRIPTION
## Summary
- Adds `RenameByParent(parent_type)` method to `DataInstanceLibrary` that renames items based on the path stem of their parent of a given type
- Uses a transactional approach: plans all renames, executes filesystem moves with rollback on error, then commits the manifest atomically via `Save()`
- Handles collisions (same target name in same directory) by appending a deterministic hash suffix
- **Performance optimizations** for large sample counts (10k+):
  - `AsSamples()`: O(N²×D) → O(N×P + S×desc) via pre-built children_of reverse index + BFS
  - `Unpack()`: Memoized transitive closure replaces 2-level grandparent aggregation (also a correctness fix for deep lineage)
  - `_build_endpoint_with_lineage()`: Endpoint cache avoids redundant recursive builds
  - `RenameByParent()`: Two-phase commit O(N×P) instead of O(R×N×P); fix O(N×R) collision detection bug
  - `_calculate_key()`: Skip redundant Pack() during Load by reusing raw YAML dict

## Test plan
- [x] 10 tests in `TestDataInstanceLibraryRenameByParent` covering basic rename, extension preservation, parent-type skipping, orphan skipping, multi-sample, collision hashing, cross-directory, filesystem state, save/load round-trip, and transactional error safety
- [x] 5 new performance tests in `TestDataInstanceLibraryPerformance` with 10k samples (40k items) validating Load, AsSamples, Trace, RenameByParent, and round-trip all complete within time budgets
- [x] All 35 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)